### PR TITLE
Improve Syslogging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ readme = "README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = "2.1.1"
+slog = "^2.1.1"
 syslog = "3.3.0"
 nix = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-syslog"
-version = "2.2.0"
+version = "0.0.12"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>", "William Laeder <codylaeder@gmail.com" ]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-syslog"
-version = "0.0.12"
+version = "0.12.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>", "William Laeder <codylaeder@gmail.com" ]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slog-syslog"
-version = "0.11.0"
-authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
+version = "2.2.0"
+authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>", "William Laeder <codylaeder@gmail.com" ]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]
 license = "MPL-2.0"
@@ -14,6 +14,6 @@ readme = "README.md"
 path = "lib.rs"
 
 [dependencies]
-slog = "2"
-syslog = "3.2.0"
+slog = "2.1.1"
+syslog = "3.3.0"
 nix = "0.9.0"


### PR DESCRIPTION
List of changes

* Creates a builder pattern to make is easier to use the `tcp`, `udp`, and `syslog` configuration(s).
* Bumps version number to be in-line with the other `slog-*` crates.
* Adds myself a contributor

