### PR TITLE
Bump Nix to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.12.0 - ????-??-??
+
+* Update nix dependency to 0.14.0
+
 ## 0.11.0 - 2017-04-29
 
 * Update slog dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ path = "lib.rs"
 [dependencies]
 slog = "^2.1.1"
 syslog = "3.3.0"
-nix = "0.9.0"
+nix = "0.14.0"


### PR DESCRIPTION
Crate was failing to compile for NetBsd because of bug in old version of Nix. Trivial update fixes this issue.