### PR TITLE
Dismiss log messages based on the log level and other small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/slog-rs/term"
 homepage = "https://github.com/slog-rs/slog"
 repository = "https://github.com/slog-rs/syslog"
 readme = "README.md"
+edition = "2018"
 
 [lib]
 path = "lib.rs"
@@ -16,4 +17,3 @@ path = "lib.rs"
 [dependencies]
 slog = "^2.1.1"
 syslog = "3.3.0"
-nix = "0.14.0"

--- a/lib.rs
+++ b/lib.rs
@@ -132,7 +132,7 @@ impl Format3164 {
 
     fn format(
         &self,
-        io: &mut io::Write,
+        io: &mut dyn io::Write,
         record: &Record,
         logger_kv: &OwnedKVList,
     ) -> io::Result<()> {

--- a/lib.rs
+++ b/lib.rs
@@ -25,10 +25,6 @@
 //! ```
 #![warn(missing_docs)]
 
-extern crate nix;
-extern crate slog;
-extern crate syslog;
-
 use slog::{Drain, Level, OwnedKVList, Record};
 use std::{fmt, io};
 use std::sync::Mutex;


### PR DESCRIPTION
Log messages that do not have a log level at least as low as the one of
the streamer will not be forwarded.
Update `try!()` macros to new `?` syntax.
Explictly specify dyn trait object in `Format3164::format`.