### PR TITLE
Bumped version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-syslog"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>", "William Laeder <codylaeder@gmail.com" ]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]


### PR DESCRIPTION
Bumped version so syslog dependency version 5.0 can be downloaded from crates.io, current version on crates.io depends on syslog 3.3.0. Syslog version 5.0 allows this crate to be cross compiled to a windows target, current dependency of version 3.3.0 doesn't allow this.