### PR TITLE
fix log level test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-syslog"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>", "William Laeder <codylaeder@gmail.com" ]
 description = "Syslog drain for slog-rs"
 keywords = ["slog", "logging", "json", "log", "syslog"]

--- a/lib.rs
+++ b/lib.rs
@@ -146,8 +146,8 @@ impl Drain for Streamer3164 {
     type Ok = ();
 
     fn log(&self, info: &Record, logger_values: &OwnedKVList) -> io::Result<()> {
-        if self.level > info.level() {
-            return Ok(())
+        if !info.level().is_at_least(self.level) {
+            return Ok(());
         }
         TL_BUF.with(|buf| {
             let mut buf = buf.borrow_mut();


### PR DESCRIPTION
Use the proper member function to filter incoming log records.
This effectively inverts a log level check that was introduced in
641816f7d2 which e. g. prevented Info level messages from being
logged at Info level whereas they showed up on Error level etc.

Reported-by: @thomasjfox, @pevogam
Signed-off-by: Philipp Gesang <philipp.gesang@intra2net.com>